### PR TITLE
TF 다운로드 링크를 마그넷에서 토렌트 파일로 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,6 +37,7 @@ dependencies {
     implementation('org.jsoup:jsoup:1.11.3')
     implementation('commons-codec:commons-codec:1.11')
     implementation('org.apache.httpcomponents:httpclient:4.5.6')
+    implementation('net.sourceforge.htmlunit:htmlunit:2.35.0')
 
     compileOnly('org.projectlombok:lombok:1.18.4')
     testImplementation('org.springframework.boot:spring-boot-starter-test')

--- a/src/main/java/com/opal/torrent/rss/impl/TFreecaImpl.java
+++ b/src/main/java/com/opal/torrent/rss/impl/TFreecaImpl.java
@@ -1,5 +1,9 @@
 package com.opal.torrent.rss.impl;
 
+import com.gargoylesoftware.htmlunit.WebClient;
+import com.gargoylesoftware.htmlunit.html.DomElement;
+import com.gargoylesoftware.htmlunit.html.HtmlPage;
+import com.opal.torrent.rss.model.QqCaptchaResult;
 import com.opal.torrent.rss.model.TBoard;
 import com.opal.torrent.rss.model.TFBoard;
 import com.opal.torrent.rss.model.TitleLink;
@@ -11,9 +15,13 @@ import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
+import org.springframework.boot.json.BasicJsonParser;
+import org.springframework.boot.json.JsonParser;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
@@ -25,8 +33,9 @@ import java.util.stream.IntStream;
 
 @Service(TFreecaImpl.SITE_SIMPLE_NAME)
 public class TFreecaImpl implements ITorrentService {
-
+    final Logger logger = LoggerFactory.getLogger(getClass());
     final static String SITE_SIMPLE_NAME = "tf";
+    final static String QQ_CAPTCHA_URL = "https://ssl.captcha.qq.com/cap_union_prehandle";
 
     @Value("${opal.torrent.rss.site.tf.url}")
     private String BASE_URL;
@@ -131,23 +140,125 @@ public class TFreecaImpl implements ITorrentService {
     @Override
     public Document queryView(String board, String boardId) throws IOException {
         Map<String, Object> mapParam = new HashMap<>();
-        mapParam.put("bo_table", board);
-        mapParam.put("wr_id", boardId);
+        mapParam.put("mode", "view");
+        mapParam.put("page", "1");
+        mapParam.put("b_id", board);
+        mapParam.put("id", boardId);
         String param = WebUtil.urlEncodeUTF8(mapParam);
-        String queryUrl = String.format("%s/info.php?%s", BASE_URL, param);
+        String queryUrl = String.format("%s/board.php?%s", BASE_URL, param);
         return Jsoup.connect(queryUrl).method(Connection.Method.GET).ignoreContentType(true).get();
     }
 
     @Override
     public String getMagnet(Document doc, String prefer) {
-        doc = Jsoup.parse(doc.outerHtml().replaceAll("<!--", "<").replaceAll("-->", ">"));
-        Elements fileNameEm = doc.select("div[class=torrent_file]");
-        if (fileNameEm.isEmpty()) {
+        Elements elements = doc.select("body");
+        if (elements.isEmpty()) {
             return null;
         }
-        int magnetIndex = getMagnetIndex(fileNameEm, prefer);
-        Elements magnetEm = doc.select("div[class=torrent_magnet]");
-        return magnetEm.get(magnetIndex).text();
+        String torrent = getTorrentLink(elements);
+        logger.info("getMagnet(): TorrentLink-> {}", torrent);
+        try (final WebClient webClient = new WebClient()) {
+            webClient.getOptions().setJavaScriptEnabled(true);
+            webClient.getOptions().setRedirectEnabled(true);
+            webClient.getOptions().setCssEnabled(false);
+            webClient.getOptions().setUseInsecureSSL(true);
+            webClient.getOptions().setThrowExceptionOnScriptError(false);
+            webClient.getOptions().setThrowExceptionOnFailingStatusCode(false);
+            
+            final HtmlPage page = webClient.getPage(torrent);
+            webClient.waitForBackgroundJavaScript(1000);
+            
+            DomElement anchor = page.getElementByName("download");
+            anchor.setAttribute("style", "display: block; width: 100px;");
+            anchor.click();
+            webClient.waitForBackgroundJavaScript(2000);
+            String url = page.getElementById("Down").getAttribute("action");
+            String key = page.getElementByName("key").getAttribute("value");
+            String ticket = page.getElementById("Ticket").getAttribute("value");
+            String randstr = page.getElementById("Randstr").getAttribute("value");
+            String userIP = page.getElementByName("UserIP").getAttribute("value");
+            Map<String, Object> mapParam = new HashMap<>();
+            mapParam.put("key", key);
+            mapParam.put("Ticket", ticket);
+            mapParam.put("Randstr", randstr);
+            mapParam.put("UserIP", userIP);
+            logger.debug("getMagnet(): mapParam-> {}", mapParam);
+            if (!StringUtils.isEmpty(url)
+                    && !StringUtils.isEmpty(key)
+                    && !StringUtils.isEmpty(ticket)
+                    && !StringUtils.isEmpty(randstr)
+                    && !StringUtils.isEmpty(userIP)) {
+                String param = WebUtil.urlEncodeUTF8(mapParam);
+                torrent = String.format("%s?%s", url, param);
+            }
+            else {
+                if (StringUtils.isEmpty(url))
+                    url = "http://file.filetender.com/file.php";
+                String appId = anchor.getAttribute("data-appid");
+                QqCaptchaResult qqCaptchaResult = getCaptchaResult(torrent, appId);
+                if (qqCaptchaResult != null) {
+                    mapParam.put("Ticket", qqCaptchaResult.getTicket());
+                    mapParam.put("Randstr", qqCaptchaResult.getRandstr());
+                    String param = WebUtil.urlEncodeUTF8(mapParam);
+                    torrent = String.format("%s?%s", url, param);
+                }
+            }
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+        }
+        logger.info("getMagnet(): torrent-> {}", torrent);
+        return torrent;
+    }
+
+    private QqCaptchaResult getCaptchaResult(String referrer, String appId) {
+        final String USER_AGENT = "Mozilla/5.0 (Windows NT 6.1; Win64; x64; rv:66.0) Gecko/20100101 Firefox/66.0";
+        try {
+            Document document = Jsoup.connect(QQ_CAPTCHA_URL)
+                                        .referrer(referrer)
+                                        .userAgent(USER_AGENT)
+                                        .data("aid", appId)
+                                        .data("accver", "1")
+                                        .data("showtype", "popup")
+                                        .data("ua", Base64.getEncoder().encodeToString(USER_AGENT.getBytes()))
+                                        .data("noheader", "1")
+                                        .data("fb", "1")
+                                        .data("tkid", appId)
+                                        .data("grayscale", "1")
+                                        .data("clientype", "2")
+                                        .data("subsid", "1")
+                                        .data("callback", "_aq_" + appId)
+                                        .method(Connection.Method.GET)
+                                        .ignoreContentType(true)
+                                        .get();
+            logger.debug("getCaptchaResult(): {}", document.text());
+            String contents = document.text().substring(document.text().indexOf("(")+1).replace(")", "");
+            JsonParser parser = new BasicJsonParser();
+            Map<String, Object> map = parser.parseMap(contents);
+            return QqCaptchaResult.builder()
+                                    .ticket((String)map.get("ticket"))
+                                    .randstr((String)map.get("randstr"))
+                                    .build();
+        }
+        catch (Exception e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    private String getTorrentLink(Elements elements) {
+        for (Element el: elements) {
+            if (el.hasAttr("href") && el.attr("href").contains("filetender")) {
+                return el.attr("href");
+            }
+            Elements children = el.children();
+            if (children.size() > 0) {
+                String torrent = getTorrentLink(children);
+                if (!StringUtils.isEmpty(torrent))
+                    return torrent;
+            }
+        }
+        return null;
     }
 
     private int getMagnetIndex(Elements elements, String prefer) {

--- a/src/main/java/com/opal/torrent/rss/model/QqCaptchaResult.java
+++ b/src/main/java/com/opal/torrent/rss/model/QqCaptchaResult.java
@@ -1,0 +1,11 @@
+package com.opal.torrent.rss.model;
+
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class QqCaptchaResult {
+    private String ticket;
+    private String randstr;
+}

--- a/src/main/java/com/opal/torrent/rss/service/CacheService.java
+++ b/src/main/java/com/opal/torrent/rss/service/CacheService.java
@@ -9,8 +9,9 @@ public class CacheService {
 
     static final String CACHE_NAME_RSS = "rss";
     static final String CACHE_NAME_RSS_BY_SITE = "rssBySite";
+    static final String CACHE_NAME_DOWNLOAD_LINK = "downloadLink";
 
-    @CacheEvict(allEntries = true, cacheNames = {CacheService.CACHE_NAME_RSS, CacheService.CACHE_NAME_RSS_BY_SITE})
+    @CacheEvict(allEntries = true, cacheNames = {CacheService.CACHE_NAME_RSS, CacheService.CACHE_NAME_RSS_BY_SITE, CacheService.CACHE_NAME_DOWNLOAD_LINK})
     @Scheduled(fixedDelayString = "${opal.torrent.rss.cache.expire}")
     public void cacheEvict() {
     }

--- a/src/main/java/com/opal/torrent/rss/service/RssService.java
+++ b/src/main/java/com/opal/torrent/rss/service/RssService.java
@@ -56,6 +56,7 @@ public class RssService {
         return channel;
     }
 
+    @Cacheable(CacheService.CACHE_NAME_DOWNLOAD_LINK)
     public String getDownloadLink(String site, String board, String boardId, String prefer) {
         ITorrentService torrentService = applicationContext.getBean(site, ITorrentService.class);
         try {

--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -1,0 +1,44 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE configuration>
+<configuration>
+
+	<appender name="dailyRollingFileAppender"
+		class="ch.qos.logback.core.rolling.RollingFileAppender">
+		<prudent>true</prudent>
+
+		<rollingPolicy
+			class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
+			<fileNamePattern>/var/log/trss.%d{yyyy-MM-dd}.log</fileNamePattern>
+			<maxHistory>30</maxHistory>
+			<totalSizeCap>100MB</totalSizeCap>
+		</rollingPolicy>
+
+		<filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+			<level>INFO</level>
+		</filter>
+
+		<encoder>
+			<pattern>%d{yyyy-MM-dd HH:mm:ss.SSS} %-5level --- [%thread]
+				%logger{35} : %msg %n</pattern>
+		</encoder>
+	</appender>
+
+	<appender name="console"
+		class="ch.qos.logback.core.ConsoleAppender">
+		<withJansi>true</withJansi>
+		<layout class="ch.qos.logback.classic.PatternLayout">
+			<Pattern>
+				%d{yyyy-MM-dd HH:mm:ss.SSS} %green([%-5level]) %yellow(%C{1.}): %msg%n%throwable
+			</Pattern>
+		</layout>
+	</appender>
+
+	<logger name="org.springframework.web" level="INFO" />
+	<logger name="com.gargoylesoftware.htmlunit" level="ERROR" />
+	<logger name="com.opal.torrent.rss" level="DEBUG" />
+
+	<root level="INFO">
+		<appender-ref ref="dailyRollingFileAppender" />
+		<appender-ref ref="console" />
+	</root>
+</configuration>


### PR DESCRIPTION
TF 다운로드 링크를 마그넷에서 filetender 사이트에 있는 토렌트 파일의 링크를 구하는 방식으로 변경하였습니다.
일단 제 나스에서는 잘 동작되는 것 같습니다.
Captcha 처리하는 부분이 정상 동작할 때도 있고, 안할 때도 있고 그런데.. 두 경우 모두 일단 토렌트 파일은 잘 받아집니다.
